### PR TITLE
refactor: simplify utility macros and improve code formatting

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,54 +1,16 @@
-"""
-    @get(collection, key, default)
-
-Short-circuiting version of [`get`](@ref). See also [`@something`](@ref).
-"""
-macro get(collection, key, default=nothing)
-    val = gensym()
-    quote
-        $val = get($(esc(collection)), $(esc(key)), nothing)
-        !isnothing($val) ? $val : $(esc(default))
-    end
-end
-
-"""Short-circuiting version of [`_getfield`](@ref)."""
-macro getfield(value, name, default=nothing)
-    :(hasfield(typeof($(esc(value))), $name) ? getfield($(esc(value)), $name) : $(esc(default)))
-end
-
-macro getfield(value, names::Expr, default=nothing)
-    tests = map(names.args) do name
-        :(hasfield(typeof($(esc(value))), $name) && (return getfield($(esc(value)), $name)))
-    end
-    quote
-        $(tests...)
-        return $(esc(default))
-    end
-end
-
-macro getproperty(value, names::Expr, default=nothing)
+macro getproperty(value, names::Expr, default = nothing)
     tests = map(names.args) do name
         :(hasproperty($(esc(value)), $name) && (return getproperty($(esc(value)), $name)))
     end
-    quote
+    return quote
         $(tests...)
         return $(esc(default))
     end
 end
 
-"""
-    _getfield(v, name, default)
-
-Return the field from a composite `v` for the given `name`, or the given `default` if no field is present.
-
-See also: `getfield`.
-"""
-_getfield(v, name::Symbol, default=nothing) = hasfield(typeof(v), name) ? getfield(v, name) : default
-_getfield(v, names, default=Some(nothing)) = something(_getfield.(Ref(v), names)..., default) # no runtime cost
-
 # https://github.com/JuliaLang/julia/issues/54454
 _nth(itr, n) = begin
-    y = iterate(Base.Iterators.drop(itr, n-1))
+    y = iterate(Base.Iterators.drop(itr, n - 1))
     isnothing(y) ? throw(BoundsError(itr, n)) : first(y)
 end
 
@@ -61,10 +23,10 @@ end
 function colors(i)
     colors = [209, 32, 81, 204, 249, 166, 37]
     c = rem(i - 1, length(colors)) + 1
-    colors[c]
+    return colors[c]
 end
 
-print_name(io::IO, var) = printstyled(io, name(var); color=colors(7))
+print_name(io::IO, var) = printstyled(io, name(var); color = colors(7))
 
 # like merge to avoid privacy issues
 # https://github.com/rafaqz/DimensionalData.jl/issues/1142

--- a/src/variable_interface.jl
+++ b/src/variable_interface.jl
@@ -1,5 +1,5 @@
 # Interface
-name(v) = @getfield v :name getmeta(v, "name", "")
+name(v) = @getproperty v (:name,) getmeta(v, "name", "")
 
 
 function unwrap end
@@ -35,7 +35,7 @@ end
 Get metadata for object `x`. If `x` does not have metadata, return `NoMetadata()`. 
 
 """
-getmeta(x) = @getfield x (:meta, :metadata) NoMetadata()
+getmeta(x) = @getproperty x (:meta, :metadata) NoMetadata()
 getmeta(x::AbstractDict) = x
 
 # like get, but handles NamedTuple
@@ -51,7 +51,7 @@ getmeta(x, key, default = nothing) = _get(meta(x), key, default)
 
 const meta = getmeta # not exported (to be removed)
 
-units(v) = @get(v, "units", nothing)
+units(v) = get(v, "units", nothing)
 
 function unit(v)
     us = units(v)


### PR DESCRIPTION
- Remove unused `@get` and `@getfield` macros and `_getfield` function
- Replace `@getfield` with `@getproperty` in variable interface
