### PR TITLE
feat(schemas): add metadata schema system with ISTP support

### DIFF
--- a/src/SpaceDataModel.jl
+++ b/src/SpaceDataModel.jl
@@ -31,7 +31,7 @@ include("coordinates/representation.jl")
 include("variable_interface.jl")
 const getdim = dim
 
-include("schemas/schema.jl"); export get_schema
+include("schemas/schema.jl"); export get_schema, SchemaDict
 
 include("times.jl");        using .Times
 include("timeseries.jl");   using .TimeSeriesAPI

--- a/src/schemas/schema.jl
+++ b/src/schemas/schema.jl
@@ -17,13 +17,32 @@ Base.getindex(schema::MetadataSchema, key) = get(rules(schema), key, nothing)
 (s::MetadataSchema)(data, key) = SchemaLookup(s, data)[key]
 
 """
+    SchemaDict(schema, data)
+    SchemaDict(schema, pairs::Pair...)
+
+Dict tagged with a [`MetadataSchema`].
+"""
+struct SchemaDict{S, K, V, D <: AbstractDict{K, V}} <: AbstractDict{K, V}
+    schema::S
+    data::D
+end
+
+SchemaDict(schema, pairs::Pair...) = SchemaDict(schema, Dict(pairs...))
+
+for f in (:length, :iterate, :getindex, :setindex!, :get)
+    @eval Base.$f(t::SchemaDict, args...) = Base.$f(t.data, args...)
+end
+
+"""
     get_schema(data)
 
-Get the appropriate metadata schema for the data.
+Get the metadata schema for `data`. Returns the tagged schema if metadata is
+a [`SchemaDict`], otherwise infers from content (e.g. `"CATDESC"` ⇒ ISTP).
 """
 get_schema(data) = _get_schema(getmeta(data))
 get_schema(f::Function, args...) = get_schema(f(args...))
 _get_schema(::Any) = DefaultSchema()
+_get_schema(t::SchemaDict) = t.schema
 function _get_schema(meta::AbstractDict)
     return haskey(meta, "CATDESC") ? ISTPSchema() : DefaultSchema()
 end

--- a/test/test_metadata_schema.jl
+++ b/test/test_metadata_schema.jl
@@ -45,6 +45,46 @@ end
     @test get(sl, :title, "default") == "default"
 end
 
+@testitem "SchemaDict" begin
+    using SpaceDataModel: SchemaDict, ISTPSchema, DefaultSchema, get_schema
+
+    @testset "Construction" begin
+        t = SchemaDict(ISTPSchema(), "UNITS" => "km/s")
+        @test t.schema isa ISTPSchema
+        @test t["UNITS"] == "km/s"
+        # Wrap an existing dict
+        d = Dict("a" => 1, "b" => 2)
+        t2 = SchemaDict(DefaultSchema(), d)
+    end
+
+    @testset "K, V inferred from wrapped dict" begin
+        t = SchemaDict(ISTPSchema(), Dict("UNITS" => "km/s"))
+        @test t isa AbstractDict{String, String}
+        @test eltype(t) === Pair{String, String}
+    end
+
+    @testset "AbstractDict interface" begin
+        t = SchemaDict(ISTPSchema(), "UNITS" => "km/s")
+        @test haskey(t, "UNITS")
+        @test get(t, "UNITS", "default") == "km/s"
+        @test "UNITS" in keys(t)
+        @test length(t) == 1
+        # Mutability when underlying dict is mutable
+        t["new"] = "value"
+        @test t["new"] == "value"
+
+        # Iteration
+        pairs_collected = collect(t)
+        @test length(pairs_collected) == 2
+    end
+
+    @testset "Schema dispatch (no content sniffing)" begin
+        # Explicit DefaultSchema overrides content sniffing
+        t_default = SchemaDict(DefaultSchema(), "CATDESC" => "would be ISTP")
+        @test get_schema((; metadata = t_default)) isa DefaultSchema
+    end
+end
+
 @testitem "resolve Patterns" begin
     using SpaceDataModel: resolve, Via
 


### PR DESCRIPTION
- MetadataSchema with DefaultSchema, ISTPSchema; rules() interface
- resolve() DSL: direct, priority, Via accessor, default patterns
- SchemaDict{S,K,V,D}: schema-tagged dict, parametric on K,V for type stability
- SchemaLookup: lazy, zero-allocation attribute access
- DimensionalData ext: getmeta(::Dimension)
