### PR TITLE
feat(schemas): coerce String ↔ Symbol keys in _get

### DIFF
--- a/src/schemas/schema.jl
+++ b/src/schemas/schema.jl
@@ -75,8 +75,8 @@ struct DefaultSchema <: MetadataSchema end
 rules(::DefaultSchema) = _DEFAULT_MAPPING
 
 const _DEFAULT_MAPPING = (
-    name = ("name", :name) => SpaceDataModel.name,
-    unit = ("unit", :unit),
+    name = "name" => SpaceDataModel.name,
+    unit = "unit",
 )
 
 include("istp.jl")

--- a/src/variable_interface.jl
+++ b/src/variable_interface.jl
@@ -38,9 +38,13 @@ Get metadata for object `x`. If `x` does not have metadata, return `NoMetadata()
 getmeta(x) = @getproperty x (:meta, :metadata) NoMetadata()
 getmeta(x::AbstractDict) = x
 
-# like get, but handles NamedTuple
+# like `get`, with String ↔ Symbol coercion and a safety net for other key-type
+# mismatches (some AbstractDicts, e.g. JSON.Object, error instead of returning default)
 _get(x, key, default) = get(x, key, default)
 _get(x::NamedTuple, key::String, default) = get(x, Symbol(key), default)
+_get(x::AbstractDict{String}, key::Symbol, default) = get(x, String(key), default)
+_get(x::AbstractDict{Symbol}, key::String, default) = get(x, Symbol(key), default)
+_get(x::AbstractDict, key, default) = key isa keytype(x) ? get(x, key, default) : default
 
 """
     getmeta(x, key, default=nothing)

--- a/test/test_metadata_schema.jl
+++ b/test/test_metadata_schema.jl
@@ -97,7 +97,7 @@ end
 
     @testset "Direct lookup" begin
         @test resolve(metadata, "UNITS") == "km/s"
-        @test resolve(metadata, :UNITS) === nothing
+        @test resolve(metadata, :UNITS) == "km/s"  # Symbol coerces to String
         @test resolve(metadata, "MISSING") === nothing
         @test resolve(metadata, md -> get(md, "name", "default")) == "default"
     end


### PR DESCRIPTION
Allows attribute lookup to work uniformly across String-keyed (HAPI, ISTP)
and Symbol-keyed metadata. Adds keytype safety net for strict AbstractDicts
(e.g. JSON.Object) that error on key-type mismatch.
