### PR TITLE
feat(metadata): add OverlayDict for layered metadata access

### DIFF
--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -23,3 +23,56 @@ Base.merge(::NoMetadata, d, rest...) = merge(d, rest...)
 
 Base.haskey(::NoMetadata, args...) = false
 Base.get(::NoMetadata, key, default = nothing) = default
+
+"""
+    OverlayDict(base, overlay)
+    OverlayDict{K, V}(base)
+
+Dictionary view where `overlay` entries shadow `base`; writes update only `overlay`.
+"""
+struct OverlayDict{K, V, B, O} <: AbstractDict{K, V}
+    base::B
+    overlay::O
+end
+
+OverlayDict{K, V}(base) where {K, V} = OverlayDict(base, Dict{K, V}())
+OverlayDict(base::B, overlay::O) where {B, O} =
+    OverlayDict{Union{keytype(base), keytype(overlay)}, Union{valtype(base), valtype(overlay)}, B, O}(base, overlay)
+
+function Base.getindex(d::OverlayDict, key)
+    return get(d.overlay, key) do
+        d.base[key]
+    end
+end
+
+function Base.get(d::OverlayDict, key, default)
+    return get(d.overlay, key) do
+        get(d.base, key, default)
+    end
+end
+
+Base.setindex!(d::OverlayDict, value, key) = setindex!(d.overlay, value, key)
+Base.haskey(d::OverlayDict, key) = haskey(d.overlay, key) || haskey(d.base, key)
+Base.length(d::OverlayDict) =
+    length(d.overlay) + count(kv -> !haskey(d.overlay, first(kv)), d.base)
+
+function Base.iterate(d::OverlayDict, state = (1, nothing))
+    phase, st = state
+    if phase == 1
+        next = isnothing(st) ? iterate(d.overlay) : iterate(d.overlay, st)
+        if next !== nothing
+            kv, st2 = next
+            return (kv, (1, st2))
+        end
+        st = nothing
+        phase = 2
+    end
+    while true
+        next = isnothing(st) ? iterate(d.base) : iterate(d.base, st)
+        isnothing(next) && break
+        kv, st = next
+        haskey(d.overlay, kv.first) && continue
+        return (kv, (2, st))
+    end
+    return nothing
+end

--- a/test/metadata.jl
+++ b/test/metadata.jl
@@ -53,3 +53,24 @@ end
     p3 = Product([1, 2, 3])
     @test p3.metadata isa NoMetadata
 end
+
+@testitem "OverlayDict" begin
+    using SpaceDataModel: OverlayDict
+
+    base = Dict("source" => "base", "base_only" => 1)
+    d = OverlayDict{String, Any}(base)
+
+    @test d["source"] == "base"
+    @test_throws KeyError d[:source]
+    @test !haskey(d, :base_only)
+    @test get(d, :source, :fallback) == :fallback
+
+    d["source"] = "overlay"
+    d["overlay_only"] = 2
+
+    @test d["source"] == "overlay"
+    @test base["source"] == "base"
+    @test keys(d) isa Base.KeySet
+    @test length(d) == 3
+    @test Dict(d) == Dict("source" => "overlay", "base_only" => 1, "overlay_only" => 2)
+end


### PR DESCRIPTION
Implements dictionary view where overlay entries shadow base entries; writes update only overlay layer.
