### PR TITLE
perf(select): keep domain variation out of the Dataset type, type-erase selectors and kwargs

### DIFF
--- a/src/SpaceDataModel.jl
+++ b/src/SpaceDataModel.jl
@@ -32,10 +32,11 @@ function available end
 include("utils.jl")
 include("metadata.jl")
 include("filepattern.jl");  export FilePattern
+include("selectors.jl")
 include("types.jl")
+include("select.jl")
 include("dataset.jl")
 include("product.jl")
-include("select.jl")
 include("variable_interface.jl")
 const getdim = dim
 include("variable.jl")

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -1,23 +1,25 @@
-"""
-    Dataset(name, source; selectors=(;), metadata=NoMetadata(), kw...)
-
-A `name`d dataset with domains for its selectors and a source that materializes it
-over a time range via [`getdata`](@ref).
-
-`selectors` maps each selector name to its domain: a single value, a collection, or a value type. 
-
-`name` may carry `{selector}` placeholders, filled when selection pins open domains; a source templates itself the same way.
-"""
-struct Dataset{S<:NamedTuple,B,MD}
+struct Dataset{S,B,MD}
     name::String
     selectors::S
     source::B
     metadata::MD
 end
 
-function Dataset(name, source; selectors=(;), metadata=NoMetadata(), kwargs...)
-    Dataset(String(name), selectors, source, merge(metadata, kwargs))
-end
+"""
+    Dataset(name, source; selectors=(;), metadata=NoMetadata(), kw...)
+
+A `name`d dataset with domains for its selectors and a source that materializes it
+over a time range via [`getdata`](@ref).
+
+`selectors` maps each selector name to its domain: a single value, a collection, or `Any` for open. Values are spelled as strings.
+
+`name` may carry `{selector}` placeholders, filled when selection pins open domains; a source templates itself the same way.
+"""
+Dataset(name, source; selectors=(;), metadata=NoMetadata(), kwargs...) =
+    Dataset(String(name), Selectors(selectors), source, merge(metadata, kwargs))
+
+# the default struct falls back to `===`, egal on those fields is pointer identity
+Base.:(==)(a::Dataset, b::Dataset) = eqfields(a, b)
 
 Base.getindex(ds::Dataset, var::Union{AbstractString,Symbol}) = Product(ds, var)
 
@@ -44,6 +46,8 @@ end
 
 Archive(pattern) = Archive(pattern, (paths, t0, t1) -> paths)
 
+Base.:(==)(a::Archive, b::Archive) = a.pattern == b.pattern && a.reader == b.reader
+
 function getdata(a::Archive, t0, t1; version="*", refresh=false, dir=datadir(), update=false, ntasks=4)
     from, to = _time(t0), _time(t1)
     urls = remotefiles(a.pattern, from, to; refresh, version)
@@ -51,10 +55,14 @@ function getdata(a::Archive, t0, t1; version="*", refresh=false, dir=datadir(), 
     return a.reader(localize(urls; dir, update, ntasks), from, to)
 end
 
+(ds::Dataset)(t0, t1; kwargs...) = getdata(ds, t0, t1; kwargs...)
+
 available(a::Archive, args...; refresh=false, version="*") = available(a.pattern, args...; refresh, version)
 remotefiles(a::Archive, args...; refresh=false, version="*") = remotefiles(a.pattern, args...; refresh, version)
 remotefiles(ds::Dataset, args...; kwargs...) = remotefiles(ds.source, args...; kwargs...)
 
 # Selection pins a dataset by rebuilding its source with the pinned values (`pin`).
-bind(src; kwargs...) = src
-bind(a::Archive; kwargs...) = Archive(a.pattern(; kwargs...), a.reader)
+bind(src, fills) = src
+bind(a::Archive, fills) = Archive(_bind(a.pattern, fills), a.reader)
+
+Base.show(io::IO, ds::Dataset) = print(io, name(ds), " ", selectors(ds))

--- a/src/filepattern.jl
+++ b/src/filepattern.jl
@@ -9,6 +9,8 @@ struct DatePart
 end
 DatePart(body::AbstractString, stop::Bool=false) = DatePart(body, _tokens(body), stop)
 
+Base.:(==)(a::DatePart, b::DatePart) = eqfields(a, b)
+
 # A keyword placeholder; `case` is 'U'/'L' for `{name|U}`/`{name|L}`, '-' for `{name}`.
 struct KeyPart
     name::Symbol
@@ -45,6 +47,8 @@ struct FilePattern{P<:Period}
     cadence::P
 end
 
+Base.:(==)(a::FilePattern, b::FilePattern) = eqfields(a, b)
+
 function FilePattern(pattern::AbstractString; cadence=Day(1), kw...)
     parts = _parse_pattern(pattern)
     _repeats(parts, cadence) &&
@@ -52,8 +56,9 @@ function FilePattern(pattern::AbstractString; cadence=Day(1), kw...)
     return FilePattern(parts, cadence)(; kw...)
 end
 
-(p::FilePattern)(; kw...) =
-    FilePattern(_merge(_Part[x isa KeyPart && haskey(kw, x.name) ? _apply(x, kw[x.name]) : x for x in p.parts]), p.cadence)
+_bind(p::FilePattern, fills) =
+    FilePattern(_merge(_Part[x isa KeyPart && haskey(fills, x.name) ? _apply(x, fills[x.name]) : x for x in p.parts]), p.cadence)
+(p::FilePattern)(; kw...) = _bind(p, kw)
 
 # Fuse adjacent literals so rendering walks fewer parts.
 function _merge(parts)
@@ -85,14 +90,25 @@ function _format(io::IO, d::DatePart, dt)
     end
 end
 
-# Fill `{key}` placeholders in a string
-function _format(pattern::AbstractString; kwargs...)
-    isempty(kwargs) && return String(pattern)
-    pairs = Iterators.flatten(
-        ("{$k}" => string(v), "{$k|U}" => uppercase(string(v)), "{$k|L}" => lowercase(string(v)))
-            for (k, v) in kwargs
-    )
-    return replace(pattern, pairs...)
+# Fill `{key}`, `{key|U}` and `{key|L}` placeholders in a string; unfilled ones stay as written.
+# Delimiters are ASCII, so byte offsets around them are valid indices in any UTF-8 string.
+function _format(pattern::AbstractString, fills)
+    isempty(fills) && return String(pattern)
+    io = IOBuffer(sizehint=ncodeunits(pattern))
+    i = j = 1
+    while (j = findnext('{', pattern, j)) !== nothing
+        k = findnext('}', pattern, j)
+        isnothing(k) && break
+        b = min(something(findnext('|', pattern, j), k), k)
+        key, case = Symbol(SubString(pattern, j + 1, b - 1)), SubString(pattern, b + 1, k - 1)
+        start, j = j, k + 1
+        haskey(fills, key) && case in ("", "U", "L") || continue
+        s = string(fills[key])
+        print(io, SubString(pattern, i, start - 1), case == "U" ? uppercase(s) : case == "L" ? lowercase(s) : s)
+        i = j
+    end
+    print(io, SubString(pattern, i))
+    return String(take!(io))
 end
 
 # Whether one step's name equals the next's, which would make a whole range fetch a single file.

--- a/src/select.jl
+++ b/src/select.jl
@@ -1,48 +1,38 @@
-_members(d) = (d,)
-_members(d::Union{Tuple,AbstractArray,AbstractSet}) = d
-
 _datasets(reg) = values(reg.datasets)
 
 """Selector names any of the registry's datasets carries."""
 function vocabulary(reg::Registry)
     names = Symbol[]
-    for ds in _datasets(reg), key in keys(selectors(ds))
-        k = key::Symbol
+    for ds in _datasets(reg), k in keys(selectors(ds))
         k in names || push!(names, k)
     end
     return names
 end
 
-# Domain membership is `==`; a Symbol answers for its String spelling.
-_eq(m, v) = m == v
-_eq(m::AbstractString, v::Symbol) = m == String(v)
+_matches(ds, k, v) = (d = get(selectors(ds), k, nothing); !isnothing(d) && _member(d, string(v)))
 
-_member(::Type{Any}, ::Any) = true
-_member(d, v) = any(m -> _eq(m, v), _members(d))
-
-_matches(ds, k, v) = (sel=selectors(ds); haskey(sel, k) && _member(sel[k], v))
-
-_supplied_match(ds, kw) = all(_matches(ds, k, v) for (k, v) in pairs(kw))
+_supplied_match(ds, sel) = all(_matches(ds, k, v) for (k, v) in sel)
 
 # A default constrains only datasets that carry it and only when not overridden.
-_defaults_match(ds, defaults, kw) =
-    all(!haskey(selectors(ds), k) || _matches(ds, k, v) for (k, v) in pairs(defaults) if !haskey(kw, k))
+_defaults_match(ds, defaults, sel) =
+    all(!haskey(selectors(ds), k) || _matches(ds, k, v) for (k, v) in defaults if !haskey(sel, k))
 
-_check_vocabulary(reg, kw) = begin
-    vocab = vocabulary(reg)
-    unknown = setdiff(keys(kw), vocab)
-    isempty(unknown) || _unknown_selectors(reg, unknown, vocab)
-end
+_check_vocabulary(reg, sel) =
+    for k in keys(sel)
+        any(ds -> haskey(selectors(ds), k), _datasets(reg)) || _unknown_selectors(reg, keys(sel))
+    end
 
 """
     filter(reg::Registry; selectors...)
 
 The rows of `reg` every supplied selector matches, each with the matched columns pinned.
 """
-function Base.filter(reg::Registry; kw...)
-    _check_vocabulary(reg, kw)
-    rows = [pin(ds, kw) for ds in _datasets(reg) if _supplied_match(ds, kw)]
-    return setproperties(reg, (; datasets=rows, defaults=merge(reg.defaults, kw)))
+Base.filter(reg::Registry; kw...) = filter(reg, Selectors(kw))
+
+function Base.filter(reg::Registry, sel::Selectors)
+    _check_vocabulary(reg, sel)
+    rows = [pin(ds, sel) for ds in _datasets(reg) if _supplied_match(ds, sel)]
+    return setproperties(reg, (; datasets=rows, defaults=merge(reg.defaults, sel)))
 end
 
 """
@@ -51,17 +41,26 @@ end
 The *one* dataset of `reg` every supplied selector matches, with omitted selectors filled from
 `reg.defaults` where the dataset carries them.
 """
-function select(reg::Registry; kw...)
-    _check_vocabulary(reg, kw)
-    cands = filter(ds -> _supplied_match(ds, kw) && _defaults_match(ds, reg.defaults, kw), _datasets(reg))
-    length(cands) == 1 || _no_single_dataset(reg, kw, cands)
-    return pin(only(cands), merge(reg.defaults, kw); complete=true)
+select(reg::Registry; kw...) = select(reg, Selectors(kw))
+
+function select(reg::Registry, sel::Selectors)
+    _check_vocabulary(reg, sel)
+    # Lazy so the happy path neither allocates a candidate list nor walks past the second match.
+    cands = Iterators.filter(ds -> _supplied_match(ds, sel) && _defaults_match(ds, reg.defaults, sel), _datasets(reg))
+    hit = iterate(cands)
+    (isnothing(hit) || !isnothing(iterate(cands, hit[2]))) && _no_single_dataset(reg, sel)
+    return pin(hit[1], merge(reg.defaults, sel); complete=true)
 end
 
-_pinned(d) = d !== Any && length(_members(d)) == 1
+_pinned(d) = d isa String
 
-_pin(::Type{Any}, v) = v
-_pin(d, v) = _members(d)[findfirst(m -> _eq(m, v), _members(d))]
+function _pin(ds, k, d, values, complete)
+    _pinned(d) && return k => d
+    haskey(values, k) || (complete && _unpinnable(ds, k, d); return k => d)
+    v = string(values[k])
+    _member(d, v) || throw(ArgumentError("$(name(ds)): $v not in domain of $k, $(_show_domain(d))"))
+    return k => v
+end
 
 """
     pin(ds, values; complete=false)
@@ -72,31 +71,28 @@ one resolves.
 """
 function pin(ds, values; complete::Bool=false)
     sel = selectors(ds)
-    all(_pinned, sel) && return ds
-    pinned = map(keys(sel), sel) do k, d
-        _pinned(d) && return only(_members(d))
-        haskey(values, k) && return _pin(d, values[k])
-        complete && throw(ArgumentError("$(name(ds)): selector $k must be given; domain $(_show_domain(d))"))
-        return d
-    end
-    nt = NamedTuple{keys(sel)}(pinned)
-    fills = NamedTuple(k => v for (k, v) in pairs(nt) if _pinned(sel[k]) || haskey(values, k))
-    return setproperties(ds, (; name=_format(ds.name; fills...), selectors=nt, source=bind(ds.source; fills...)))
+    all(p -> _pinned(p.second), sel) && return ds
+    pinned = Selectors(Pair{Symbol,Domain}[_pin(ds, k, d, values, complete) for (k, d) in sel])
+    fills = Selectors(Pair{Symbol,Domain}[p for p in pinned if _pinned(p.second)])
+    return setproperties(ds, (; name=_format(ds.name, fills), selectors=pinned, source=bind(ds.source, fills)))
 end
 
-_show_domain(d) = d === Any ? "*" : _pinned(d) ? string(only(_members(d))) : "{" * join(_members(d), ",") * "}"
-_show_selectors(nt) = join(("$k=$(_show_domain(v))" for (k, v) in pairs(nt)), " ")
+@noinline _unpinnable(ds, k, d) =
+    throw(ArgumentError("$(name(ds)): selector $k must be given; domain $(_show_domain(d))"))
 
-@noinline function _unknown_selectors(reg, unknown, vocab)
+@noinline function _unknown_selectors(reg, supplied)
+    vocab = vocabulary(reg)
+    unknown = setdiff(supplied, vocab)
     label = length(unknown) == 1 ? "selector" : "selectors"
     throw(ArgumentError("$(reg.name): unknown $label $(join(unknown, ", ")); known: $(join(vocab, ", "))"))
 end
 
-@noinline function _no_single_dataset(reg, kw, cands)
+@noinline function _no_single_dataset(reg, sel)
+    cands = [ds for ds in _datasets(reg) if _supplied_match(ds, sel) && _defaults_match(ds, reg.defaults, sel)]
     listed = isempty(cands) ? _datasets(reg) : cands
     n = isempty(cands) ? "no dataset" : "$(length(cands)) datasets"
     throw(ArgumentError("""
-        $(reg.name): $n for $(_show_selectors(kw)) (defaults $(_show_selectors(reg.defaults))).
+        $(reg.name): $n for $(sel), default selectors $(reg.defaults).
         Available:
-        $(join(("  $(name(ds)): $(_show_selectors(selectors(ds)))" for ds in listed), "\n"))"""))
+        $(join(("  $(name(ds)): $(selectors(ds))" for ds in listed), "\n"))"""))
 end

--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -1,0 +1,60 @@
+"""A selector's admissible spellings: one, a set of them, or `Any` for open."""
+const Domain = Union{String,Vector{String},Type{Any}}
+
+# Selector each mapped to its [`Domain`](@ref).
+# Vector-backed, not a `Dict` or a `NamedTuple`: over the few keys a linear scan beats hashing
+struct Selectors <: AbstractDict{Symbol,Domain}
+    pairs::Vector{Pair{Symbol,Domain}}
+    Selectors(pairs::Vector{Pair{Symbol,Domain}}) = new(pairs)  # keeps `Selectors(kv)` from overwriting the convert fallback
+end
+
+_domain(d) = string(d)
+_domain(::Type{Any}) = Any
+_domain(d::Union{Tuple,AbstractArray,AbstractSet}) = length(d) == 1 ? string(only(d)) : String[string(x) for x in d]
+
+Selectors(kv) = Selectors(Pair{Symbol,Domain}[k => _domain(v) for (k, v) in pairs(kv)])
+
+Base.parent(s::Selectors) = getfield(s, :pairs)
+Base.length(s::Selectors) = length(parent(s))
+Base.iterate(s::Selectors, i...) = iterate(parent(s), i...)
+function Base.get(s::Selectors, k::Symbol, default)
+    for (key, d) in parent(s)
+        key === k && return d
+    end
+    return default
+end
+
+Base.getproperty(s::Selectors, k::Symbol) = s[k]
+Base.propertynames(s::Selectors) = Tuple(keys(s))
+
+# Base's AbstractDict merge hands back a `Dict`
+function Base.merge(a::Selectors, b::Selectors)
+    isempty(a) && return b
+    isempty(b) && return a
+    out = Pair{Symbol,Domain}[k => get(b, k, d) for (k, d) in a]
+    for p in b
+        haskey(a, p.first) || push!(out, p)
+    end
+    return Selectors(out)
+end
+
+_member(::Type{Any}, v) = true
+_member(d::String, v) = d == v
+_member(d::Vector{String}, v) = v in d
+
+_show_domain(::Type{Any}) = "*"
+_show_domain(d::String) = d
+_show_domain(d) = "{" * join(d, ",") * "}"
+
+function Base.show(io::IO, s::Selectors)
+    isempty(s) && return print(io, "(; )")
+    print(io, '(')
+    for (i, (k, v)) in enumerate(s)
+        Base.show_sym(io, k)
+        print(io, " = ")
+        show(IOContext(io, :typeinfo => Any), v)
+        i < length(s) && print(io, ", ")
+    end
+    length(s) == 1 && print(io, ',')
+    return print(io, ')')
+end

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,22 +1,17 @@
 const _Model = Union{Registry,Dataset,Product}
 
-Base.show(io::IO, p::_Model) = print(io, name(p))
+Base.show(io::IO, p::Union{Registry,Product}) = print(io, name(p))
 _show_ctor(io, x, vals...) = (print(io, nameof(typeof(x)), '('); join(io, vals, ", "); print(io, ')'))
 
 Base.show(io::IO, a::Archive) = _show_ctor(io, a, a.pattern, a.reader)
 function Base.show(io::IO, t::Transformed)
     _isdefault(t.metadata) ? _show_ctor(io, t, t.f, t.source) :
-                             _show_ctor(io, t, t.f, t.source, t.metadata)
+    _show_ctor(io, t, t.f, t.source, t.metadata)
 end
 
 _isdefault(v) = false
 _isdefault(::NoMetadata) = true
 _isdefault(v::Union{AbstractDict,Tuple,NamedTuple}) = isempty(v)
-
-_typename(x) = nameof(typeof(x))
-_typename(x::AbstractArray{T,N}) where {T,N} = string(nameof(typeof(x)), "{$T, $N}")
-_typename(::AbstractVector{<:Dataset}) = "Vector{Dataset}"
-_print_type(io, x) = print(io, " (", _typename(x), "): ")
 
 _println_value(io, value, prefix="  ") = (println(io); print(io, prefix, "  ", value))
 _println_value(io, value::AbstractArray{<:Number}, prefix="  ") = (println(io); print(io, prefix, "  ", value))
@@ -24,13 +19,6 @@ function _println_value(io, value::Union{AbstractVector,AbstractDict,Tuple,Named
     for (k, v) in pairs(value)
         println(io)
         print(io, prefix, "  ", k, ": ", v)
-    end
-end
-# A registry's rows print with their remaining domains: the listing is the discovery UX.
-function _println_value(io, dss::AbstractVector{<:Dataset}, prefix="  ")
-    for ds in dss
-        println(io)
-        print(io, prefix, "  ", name(ds), ": ", _show_selectors(selectors(ds)))
     end
 end
 
@@ -43,8 +31,7 @@ end
             v = getfield(p, $sf)
             if !_isdefault(v)
                 println(io)
-                print(io, "  ", $title)
-                _print_type(io, v)
+                print(io, "  ", $title, ": ")
                 _println_value(io, v)
             end
         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -4,19 +4,19 @@
 A relation of [`Dataset`](@ref)s: rows sharing a selector vocabulary. 
 A mission, an instrument, or any other grouping is a `Registry`.
 """
-struct Registry{D,MD,K}
+struct Registry{D,MD}
     name::String
     datasets::D
     metadata::MD
-    defaults::K
+    defaults::Selectors
 end
 
 function Registry(; name="", datasets=[], metadata=NoMetadata(), defaults=(;), kwargs...)
-    Registry(name, datasets, merge(metadata, kwargs), defaults)
+    Registry(name, datasets, merge(metadata, kwargs), Selectors(defaults))
 end
 Registry(name, datasets; kw...) = Registry(; name, datasets, kw...)
 
-Base.getindex(reg::Registry; kw...) = select(reg; kw...)
+Base.getindex(reg::Registry; kw...) = select(reg, Selectors(kw))
 
 # https://spase-group.org/data/model/spase-2.7.0/spase-2_7_0_xsd.html#http___www.spase-group.org_data_schema_Spase_Catalog
 # Listing of events or observational notes.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,5 @@
+eqfields(a::T, b::T) where {T} = all(i -> getfield(a, i) == getfield(b, i), 1:nfields(a))
+
 macro getproperty(value, names::Expr, default = nothing)
     tests = map(names.args) do name
         :(hasproperty($(esc(value)), $name) && (return getproperty($(esc(value)), $name)))

--- a/src/workload.jl
+++ b/src/workload.jl
@@ -1,11 +1,15 @@
 function workload()
     io = IOContext(IOBuffer(), :color => true)
-    pattern = FilePattern("https://example.com/{probe|U}/{probe}_l1_{t:yyyymmdd}_v{version}.cdf")
-    ds = Dataset("demo", Archive(pattern); selectors = (; probe = ("a", "b")))
-    reg = Registry("reg", [ds]; defaults = (; probe = "a"))
+    pattern = FilePattern("https://example.com/{probe|U}/{probe}_{level}_{t:yyyymmdd}_v{version}.cdf")
+    pattern(DateTime(2020, 1, 1); probe="a", level="l1", version="01")
+
+    ds = Dataset("demo_{level}", Archive(pattern); selectors=(; probe=("a", "b"), level=("l1", "l2")))
+    reg = Registry("reg", [ds]; defaults=(; probe="a"))
     show(io, MIME"text/plain"(), ds)
     show(io, MIME"text/plain"(), reg)
     show(io, MIME"text/plain"(), ds["var1"])
-    reg[probe = "b"]
+    reg[probe="b", level="l2"]
     return
 end
+
+ccall(:jl_generating_output, Cint, ()) == 1 && workload()

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -7,25 +7,26 @@
     open = Dataset("open", Archive(FilePattern("{rate}_{level}_{t:yyyymmdd}.cdf")); selectors=(; rate="raw", level=Any))
     reg = Registry("MGF", [hz, daily, open]; defaults=(; rate="8sec", probe="ts1", coord="dsi"))
 
+    @test sprint(show, open.selectors) == "(rate = \"raw\", level = Any)"
     @test vocabulary(reg) == [:probe, :rate, :coord, :level]
     # A fully pinned dataset comes back as is
     @test reg[] === daily
     # A default the dataset does not carry is ignored; a supplied selector it lacks excludes it.
     ds = reg[rate="64hz"]
-    @test ds.name == "hz_64hz"
+    @test reg[rate = "64hz"] == Dataset("hz_64hz", Archive(FilePattern("TS1/ts1_64hz_dsi_{t:yyyymmdd}.cdf")); selectors=(; probe="ts1", rate="64hz", coord="dsi"))
     @test ds.source.pattern(Date(2017, 3, 27)) == "TS1/ts1_64hz_dsi_20170327.cdf"
     @test_throws ArgumentError reg[coord="gse"]
-    @test reg[rate="raw", level="l2"].selectors == (; rate="raw", level="l2")
+    @test NamedTuple(reg[rate="raw", level="l2"].selectors) == (; rate="raw", level="l2")
     @test_throws ArgumentError reg[rate="raw"]
     @test_throws ArgumentError reg[rate="1hz"]
-    @test reg[rate="64hz", probe=:ts2].selectors.probe == "ts2"
+    @test NamedTuple(reg[rate="64hz", probe=:ts2].selectors).probe == "ts2"
     # A spelling outside the domain is rejected, not coerced.
     @test_throws ArgumentError reg[rate="64hz", probe="TS2"]
 
     # Filtering narrows and pins but never throws on an unmatched value.
     f = filter(reg; probe="ts2")
     @test [ds.name for ds in f.datasets] == ["hz_{rate}"]
-    @test selectors(only(f.datasets)).probe == "ts2"
+    @test NamedTuple(selectors(only(f.datasets))).probe == "ts2"
     @test isempty(filter(reg; rate="1hz").datasets)
 end
 


### PR DESCRIPTION
Selectors, a vector-backed AbstractDict, replaces the per-shape NamedTuple in
Dataset.selectors, Registry.defaults and pin's fills, and select/filter/getindex
keep only a one-line keyword method over positional ones. Each additional selector
vocabulary cost ~140 ms of compilation; it now costs ~9 ms.
